### PR TITLE
Unable to fetch new access token after expiry

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -189,7 +189,7 @@ export default class Auth {
             }
             let refreshToken = await this.cache.getRefreshToken(input.userId)
             if (refreshToken) {
-                const tokenResponse = await this.refreshTokens(refreshToken, scope)
+                const tokenResponse = await this.refreshTokens({refreshToken.refreshToken, scope})
                 if (tokenResponse && tokenResponse.refreshToken) {
                     this.cache.saveRefreshToken(tokenResponse)
                 }


### PR DESCRIPTION
The `refreshTokens` method expects a single parameter, however while calling this method from the `aquireTokenSilent`, two parameters are sent (_refreshToken_ and _scope_) which leads to `"Invalid Parameter: scope"` error. 

This method invocation also has another issue, where "**refreshToken**" is sent as a parameter which is an object and not actually the refresh token which is required to fetch the new accessToken.

This PR addresses this issue #17 