### PR TITLE
Fixes the podspec

### DIFF
--- a/ios/AzureAuth.podspec
+++ b/ios/AzureAuth.podspec
@@ -1,23 +1,14 @@
-
 Pod::Spec.new do |s|
   s.name         = "AzureAuth"
   s.version      = "1.0.0"
-  s.summary      = "AzureAuth"
-  s.description  = <<-DESC
-                  AzureAuth
-                   DESC
-  s.homepage     = ""
+  s.summary      = "React Native library implementing Azure AD OAuth2 API"
+  s.homepage     = "https://github.com/vmurin/react-native-azure-auth"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "vmurin" => "vmurin@gmail.com" }
+  s.author       = { "vmurin" => "vmurin@gmail.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/AzureAuth.git", :tag => "master" }
-  s.source_files  = "AzureAuth/**/*.{h,m}"
+  s.source_files  = "AzureAuth.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
-
 end
-


### PR DESCRIPTION
I had to make a couple of change to the podspec to make it work.

* CocoaPods refused to install the pod without a homepage field in the podspec
* The `source_files` pattern was incorrect which resulted in the library not getting picked up
* Adds a better summary
* Removes the description field as it’s optional (and was the same as the summary)