### PR TITLE
lower case user id token when generating the refresh token

### DIFF
--- a/src/token/baseTokenItem.js
+++ b/src/token/baseTokenItem.js
@@ -29,25 +29,28 @@ export default class BaseTokenItem {
     }
 
     static createRefreshTokenKey(clientId, userId) {
+      const lowerCaseUserId = userId ? userId.toLowerCase() : userId
         return Base64.encodeURI(clientId) +
             TOKEN_CACHE_KEY_DELIMITER +
-            Base64.encodeURI(userId)
+            Base64.encodeURI(lowerCaseUserId)
     }
 
     static createAccessTokenKey(clientId, userId, scope) {
+      const lowerCaseUserId = userId ? userId.toLowerCase() : userId
         return Base64.encodeURI(clientId) +
             TOKEN_CACHE_KEY_DELIMITER +
-            Base64.encodeURI(userId) +
+            Base64.encodeURI(lowerCaseUserId) +
             TOKEN_CACHE_KEY_DELIMITER +
             Base64.encodeURI(scope.toString())
     }
 
     static createTokenKeyPrefix(clientId, userId) {
-        let prefix = Base64.encodeURI(clientId) +
-        TOKEN_CACHE_KEY_DELIMITER
+        let prefix = Base64.encodeURI(clientId) + TOKEN_CACHE_KEY_DELIMITER
         if (userId) {
-            prefix = prefix + Base64.encodeURI(userId)
+            const lowerCaseUserId = userId ? userId.toLowerCase() : userId
+            prefix = prefix + Base64.encodeURI(lowerCaseUserId)
         }
+
         return prefix
     }
 


### PR DESCRIPTION
@vmurin had some local changes on my fork, where I wanted for a long time to PR you, and now I do...

Sorry for the delay!

As for this change, as it was a long time ago, I‘m not sure why this change was needed, but it might be something with the cache? Anyhow, this has solved an issue for me back then

See if makes sense