### PR TITLE
Fix a crash on "acquireTokenSilent" method, which happens when input is undefined

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -22,7 +22,7 @@ function responseHandler (response, exceptions = {}) {
  *
  * @export Auth
  * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols
- * 
+ *
  * @class Auth
  */
 export default class Auth {
@@ -50,10 +50,10 @@ export default class Auth {
    * @param {String} parameters.redirectUri where the AS will redirect back after success or failure.
    * @param {String} parameters.state random string to prevent CSRF attacks.
    * @param {String} parameters.scope a space-separated list of scopes that you want the user to consent to.
-   * @param {String} parameters.prompt (optional) indicates the type of user interaction that is required. 
+   * @param {String} parameters.prompt (optional) indicates the type of user interaction that is required.
    *    The only valid values at this time are 'login', 'none', and 'consent'.
    * @returns {String} authorize url with specified parameters to redirect to for AuthZ/AuthN.
-   * 
+   *
    * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oauth-code
    *
    * @memberof Auth
@@ -64,12 +64,12 @@ export default class Auth {
                 responseType: { required: true, toName: 'response_type' },
                 scope: { required: true },
                 state: { required: true },
-                prompt: {} 
+                prompt: {}
             },
-            validate: false // not declared params are allowed: 
+            validate: false // not declared params are allowed:
         }, parameters)
-        return this.client.url('authorize', 
-            {...query, 
+        return this.client.url('authorize',
+            {...query,
                 client_id: this.clientId,
                 redirect_uri: this.redirectUri
             })
@@ -78,7 +78,7 @@ export default class Auth {
     /**
    * Builds the full logout endpoint url in the Authorization Server (AS) with given parameters.
    * https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=[URI]&redirect_uri=[URI]
-   * 
+   *
    * @returns {String} logout url with default parameter
    *
    * @memberof Auth
@@ -96,7 +96,7 @@ export default class Auth {
    * @param {Object} input input used to obtain tokens from a code
    * @param {String} input.code code returned by `/authorize`.
    * @param {String} input.redirectUri original redirectUri used when calling `/authorize`.
-   * @param {String} input.scope A space-separated list of scopes. 
+   * @param {String} input.scope A space-separated list of scopes.
    *    The scopes requested in this leg must be equivalent to or a subset of the scopes requested in the first leg
    * @returns {Promise}
    * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oauth-code#request-an-access-token
@@ -113,9 +113,9 @@ export default class Auth {
         }, input)
 
         return this.client
-            .post('token', 
-                {...payload, 
-                    client_id: this.clientId, 
+            .post('token',
+                {...payload,
+                    client_id: this.clientId,
                     redirect_uri: this.redirectUri,
                     grant_type: 'authorization_code'})
             .then(responseHandler)
@@ -163,11 +163,11 @@ export default class Auth {
 
     /**
      * Try to obtain token silently without user interaction
-     * 
-     * @param {Object} parameters 
+     *
+     * @param {Object} parameters
      * @param {String} parameters.userId user login name (e.g. from Id token)
      * @param {String} parameters.scope scopes requested for the issued tokens.
-     * 
+     *
      * @memberof Auth
      */
     async acquireTokenSilent(parameters = {}) {
@@ -177,7 +177,7 @@ export default class Auth {
                 scope: { required: true }
             }
         }, parameters)
-        const scope = new Scope(input.scope)   
+        const scope = input? new Scope(input.scope) : new Scope()
 
         try {
             let accessToken = await this.cache.getAccessToken(input.userId, scope)
@@ -214,7 +214,7 @@ export default class Auth {
    * @returns {Promise}
    * @see https://developer.microsoft.com/en-us/graph/docs/concepts/overview
    * @see https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_get
-   * 
+   *
    * @memberof Auth
    */
     msGraphRequest(parameters = {}) {
@@ -235,10 +235,10 @@ export default class Auth {
 
     /**
      * Clear persystent cache - AsyncStorage - for given client ID and user ID or ALL users
-     * 
+     *
      * @param {String} userId ID of user whose tokens will be cleared/deleted
      *      if ommited - tokens for ALL users and current client will be cleared
-     * 
+     *
      * @memberof Auth
      */
     async clearPersistenCache(userId = null) {

--- a/src/token/accessTokenItem.js
+++ b/src/token/accessTokenItem.js
@@ -39,7 +39,7 @@ export default class AccessTokenItem extends BaseTokenItem{
 
     static fromJson(objStr) {
         const rawObject = BaseTokenItem.rawObjectFromJson(objStr)
-        if (!rawObject || !obj['accessToken']) {
+        if (!rawObject || !objStr['accessToken']) {
             return null
         }
         const obj = Object.create(AccessTokenItem.prototype)


### PR DESCRIPTION
The main fix is on the "AccessTokenItem.js" – see bellow

(if the whitespace differences is an issue, I can fix it)