### PR TITLE
allow image blobs in the http Response

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -13,6 +13,9 @@ const { AzureAuth } = NativeModules
 function responseHandler (response, exceptions = {}) {
     if (response.ok && response.json) {
         return toCamelCase(response.json, exceptions)
+    } else if(response.ok && response.data) {
+        const binaryData = new Buffer(response.data, 'binary').toString('base64');
+        return binaryData;
     }
     throw new AuthError(response)
 }

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -13,9 +13,8 @@ const { AzureAuth } = NativeModules
 function responseHandler (response, exceptions = {}) {
     if (response.ok && response.json) {
         return toCamelCase(response.json, exceptions)
-    } else if(response.ok && response.data) {
-        const binaryData = new Buffer(response.data, 'binary').toString('base64');
-        return binaryData;
+    } else if(response.ok && response.blob) {
+        return response.blob
     }
     throw new AuthError(response)
 }

--- a/src/networking/index.js
+++ b/src/networking/index.js
@@ -88,9 +88,8 @@ export default class Client {
         let response = await fetch(url, options)
         const payload = { status: response.status, ok: response.ok, headers: response.headers }
 
-        if (response.statusText === 'ok') {
+        if (response.ok) {
             if (response.headers.get('Content-Type').startsWith('image')) {
-
                 try {
                     const blob = await response.blob()
                     return { ...payload, blob }

--- a/src/networking/index.js
+++ b/src/networking/index.js
@@ -87,16 +87,32 @@ export default class Client {
 
         let response = await fetch(url, options)
         const payload = { status: response.status, ok: response.ok, headers: response.headers }
-        try {
-            const json = await response.json()
-            return { ...payload, json }
-        } catch (error) {
-            try {
-                const text = await response.text()
-                return { ...payload, text }
-            } catch (err) {
-                return { ...payload, text: response.statusText }
-            }
+
+        if (response.statusText === 'ok') {
+            if (response.headers.get('Content-Type').startsWith('image')) {
+
+                try {
+                    const blob = await response.blob()
+                    return { ...payload, blob }
+                } catch (err) {
+                    return { ...payload, text: response.statusText };
+                }
+            } else {
+                try {
+                    const json = await response.json()
+                    return { ...payload, json }
+                } catch (error) {
+                    try {
+                        const text = await response.text()
+                        return { ...payload, text }
+                    } catch (err) {
+                        return { ...payload, text: response.statusText }
+                    }
+        
+                }
+            }            
+        } else {
+            return { ...payload, text: response.statusText }
         }
     }
 }


### PR DESCRIPTION
Allowing a pass-thru of the raw blob response when making calls to return image/* content type on the graph client (ie /me/photos/$value)