### PR TITLE
Update userId selector of decoded id token in case of V1 token

### DIFF
--- a/src/token/baseTokenItem.js
+++ b/src/token/baseTokenItem.js
@@ -37,7 +37,7 @@ export default class BaseTokenItem {
         this.rawIdToken = tokenResponse.idToken
         let decodedIdToken = extractIdToken(tokenResponse.idToken)
 
-        this.userId = decodedIdToken.preferred_username
+        this.userId = decodedIdToken.preferred_username || decodedIdToken.unique_name
         this.userName = decodedIdToken.name
         this.tenantId = decodedIdToken.tid
         this.idTokenExpireOn = parseInt(decodedIdToken.exp)*1000


### PR DESCRIPTION
When changing the `authorityUrl` option in the `AzureAuth` constructor to the endpoint for fetching V1 tokens, the selector for assigning the `userId` returns undefined.

This happens in the following line in the file: `baseTokenItems.js`.
```
this.userId = decodedIdToken.preferred_username
```

That is because `preferred_username` property is not available in a V1 token.
As described in the [payload claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#payload-claims) of the Azure AD docs, "The profile scope is required to receive this claim".

The profile scope is only available in V2 tokens, hence this property will never be part of a decoded V1 token.

To fix this issue, I updated the selector to use the property `unique_name` in case the `preferred_username` property is not available (V1 token).