### PR TITLE
Added B2C ID Token Fields

### DIFF
--- a/src/token/baseTokenItem.js
+++ b/src/token/baseTokenItem.js
@@ -37,9 +37,18 @@ export default class BaseTokenItem {
         this.rawIdToken = tokenResponse.idToken
         let decodedIdToken = extractIdToken(tokenResponse.idToken)
 
-        this.userId = decodedIdToken.preferred_username || decodedIdToken.unique_name || decodedIdToken.given_name
+        this.userId = decodedIdToken.preferred_username || decodedIdToken.unique_name || decodedIdToken.sub
         this.userName = decodedIdToken.name || decodedIdToken.given_name
-        this.tenantId = decodedIdToken.tid || decodedIdToken.sub
+        if (decodedIdToken.tid) this.tenantId = decodedIdToken.tid
+        else {
+            const { iss } = decodedIdToken
+            if (iss) {
+                const httpsLength = 'https://'.length
+                const b2cSuffixIndex = iss.indexOf('.b2clogin.com')
+                // parse then tenant id out of the iss string
+                this.tenantId = iss.substring(httpsLength, b2cSuffixIndex)
+            }
+        }
         this.idTokenExpireOn = parseInt(decodedIdToken.exp)*1000
     }
 

--- a/src/token/baseTokenItem.js
+++ b/src/token/baseTokenItem.js
@@ -37,9 +37,9 @@ export default class BaseTokenItem {
         this.rawIdToken = tokenResponse.idToken
         let decodedIdToken = extractIdToken(tokenResponse.idToken)
 
-        this.userId = decodedIdToken.preferred_username || decodedIdToken.unique_name
-        this.userName = decodedIdToken.name
-        this.tenantId = decodedIdToken.tid
+        this.userId = decodedIdToken.preferred_username || decodedIdToken.unique_name || decodedIdToken.given_name
+        this.userName = decodedIdToken.name || decodedIdToken.given_name
+        this.tenantId = decodedIdToken.tid || decodedIdToken.sub
         this.idTokenExpireOn = parseInt(decodedIdToken.exp)*1000
     }
 


### PR DESCRIPTION
 The `username`, `name` and `tid` were all missing from a default implementation of the Azure Directory B2C (ADB2C) idToken. This PR is a small adjustment to be made based off of a current, barebones Microsoft Azure implementation of ADB2C, it should fix the error:

`Error: Id is null or undefined: `

Which occurs if the username field is missing.

