### PR TITLE
Fix closeOnLoad not working

### DIFF
--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -117,21 +117,24 @@ export default class WebAuth {
    *  Removes Azure session
    *
    * @param {Object} options parameters to send
-   * @param {Boolean} [options.closeOnLoad] close browser window on 'Loaded' event (works only on iOS)
+   * @param {Boolean} [options.ephemeralSession=true] whether to use ephemeral session or not
+   * @param {Boolean} [options.closeOnLoad=true] close browser window on 'Loaded' event (works only on iOS)
    * @returns {Promise}
    *
    * @memberof WebAuth
    */
-    clearSession(options = {closeOnLoad: true}) {
+     clearSession({ephemeralSession = true, closeOnLoad = true} = {}) {
+        const options = { ephemeralSession, closeOnLoad };
         const { client, agent } = this
         const parsedOptions = validate({
             parameters: {
+                ephemeralSession: { required: true },
                 closeOnLoad: { required: true },
             },
             validate: true // not declared params are NOT allowed:
         }, options)
 
         const logoutUrl = client.logoutUrl()
-        return agent.openWeb(logoutUrl, parsedOptions.closeOnLoad)
+        return agent.openWeb(logoutUrl, parsedOptions.ephemeralSession, parsedOptions.closeOnLoad)
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -312,9 +312,10 @@ declare class WebAuth {
    *  Removes Azure session
    *
    * @param {Object} options parameters to send
-   * @param {Boolean} [options.closeOnLoad] close browser window on 'Loaded' event (works only on iOS)
+   * @param {Boolean} [options.ephemeralSession=true] whether to use ephemeral session or not
+   * @param {Boolean} [options.closeOnLoad=true] close browser window on 'Loaded' event (works only on iOS)
    */
-  clearSession(options?: { closeOnLoad: boolean }): Promise<void>;
+  clearSession(options?: { ephemereSession: boolean, closeOnLoad: boolean }): Promise<void>;
 }
 
 declare class AzureAuth {


### PR DESCRIPTION
Second parameter for agent.openWeb is ephemeralSession, but currently closeOnLoad is sent for it.
This change adds a new ephemeralSession option to clearSession and fixes agent.openWeb arguments.

Fixes https://github.com/vmurin/react-native-azure-auth/issues/122