### PR TITLE
Fix iOS autolinking

### DIFF
--- a/AzureAuth.podspec
+++ b/AzureAuth.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-package = JSON.parse(File.read(File.join(__dir__, "../package.json")))
+package = JSON.parse(File.read(File.join(__dir__, "./package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "AzureAuth"
@@ -8,12 +8,12 @@ Pod::Spec.new do |s|
   s.summary      = package["description"]
   s.homepage     = "https://github.com/vmurin/react-native-azure-auth"
   s.license      = "MIT"
-  s.license      = { :type => "MIT", :file => "../LICENSE" }
+  s.license      = { :type => "MIT", :file => "./LICENSE" }
   s.authors      = { "AzureAuth" => "vmurin@gmail.com" }
   s.platforms    = { :ios => "9.0" }
   s.source       = { :git => "https://github.com/vmurin/react-native-azure-auth.git", :tag => "v#{s.version}" }
 
-  s.source_files = "*.{h,m}"
+  s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"


### PR DESCRIPTION
Autolinking does not work on iOS because the podspec file is not found in the root of the project.

This change moves the podspec file to the root and updates the relative paths in it accordingly.