### PR TITLE
Fix: Gradle 9 incompatibility warning. Repository update jcenter() -> mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 


### PR DESCRIPTION
jcenter() is deprecated on gradle 9, the repository is updated to mavenCentral() which is the recommended repo now.

the error:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```

replacing the repository jcenter() for mavenCentral() on .\android\build.gradle fixes the deprecation warning