### PR TITLE
#226 Allow cache persistence to be configured

### DIFF
--- a/src/token/__tests__/cache.spec.js
+++ b/src/token/__tests__/cache.spec.js
@@ -6,9 +6,13 @@ const clientId = '123'
 const userId = 'userId'
 
 describe('token Cache', () => {
-    const cacheInstance = new TokenCache({clientId: clientId, persistent: true})
+    afterEach(() => {
+      // clear the instance to allow testing object construction
+      TokenCache["_instance"] = null
+    })
 
-    it('should be singletone', () => {
+    it('should be a singleton', () => {
+        const cacheInstance = new TokenCache({clientId: clientId, persistent: true})
         expect((new TokenCache({clientId: '123222'})).clientId).toBe(clientId)
     })
 
@@ -17,7 +21,22 @@ describe('token Cache', () => {
     })
 
     it('should return refresh token', () => {
+        const cacheInstance = new TokenCache({clientId: clientId, persistent: true})
         expect(cacheInstance.getRefreshToken(userId)).resolves.toMatchSnapshot()
     })
 
+    it("should default to persistent", () => {
+        expect(new TokenCache({ clientId: "123222" }).persistent).toBe(true)
+        expect(new TokenCache({ clientId: "123222", persistent: null }).persistent).toBe(true)
+        expect(new TokenCache({ clientId: "123222", persistent: undefined }).persistent).toBe(true)
+    })
+
+    it("should throw when input parameters are incorrect type", () => {                
+        expect(() => new TokenCache({ clientId: "123222", persistent: "123" }))
+            .toThrow(/Parameters with wrong type/)
+    })
+
+    it("should allow persistence to be disabled", () => {        
+        expect(new TokenCache({ clientId: "123222", persistent: false }).persistent).toBe(false)
+    })
 })

--- a/src/token/cache.js
+++ b/src/token/cache.js
@@ -4,8 +4,6 @@ import AccessTokenItem from './accessTokenItem'
 import RefreshTokenItem from './refreshTokenItem'
 import BaseTokenItem from './baseTokenItem'
 
-let _instance = null
-
 /**
  * Token persistent cache
  *
@@ -20,24 +18,25 @@ let _instance = null
  * @memberof TokenCache
  */
 export default class TokenCache {
+    static _instance
     constructor(input = {}) {
         // for better testability check params first
         const params = validate({
             parameters: {
                 clientId: { required: true },
-                persistent: { required: false },
+                persistent: { required: false, type: 'boolean' },
             }
         }, input)
 
-        if (_instance) {
-            return _instance
+        if (TokenCache._instance) {
+            return TokenCache._instance
         }
 
         this.cache = {}
         this.clientId = params.clientId
-        this.persistent = params.persistent || true // by default enabled
+        this.persistent = params.persistent != null ? params.persistent : true // by default enabled
 
-        _instance = this
+        TokenCache._instance = this
     }
 
     async saveAccessToken(tokenResponse) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,8 +7,8 @@ interface AuthOptions {
 interface AzureAuthOptions {
   /** @param {String} clientId your AzureAuth client identifier */
   clientId: string;
-  /** @param {boolean} [persistentCache] should store token cache between the app starts; defaults to true */
-  persistentCache?: string;
+  /** @param {Boolean} [persistentCache] should store token cache between the app starts; defaults to true */
+  persistentCache?: boolean;
   /** @param {String} [authorityUrl] optional Azure authority if you want to replace default v2 endpoint (`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/`) */
   authorityUrl?: string;
   /** @param {String} [tenant] uses given tenant in the default authority URL; default is `common` */


### PR DESCRIPTION
I have updated the cache to validate and propagate the `persistent` argument (#226). I also changed the singleton instance to use a static field, hope you don't mind, to facilitate unit testing.