### PR TITLE
Implement login_hint

### DIFF
--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -37,6 +37,9 @@ export default class WebAuth {
    *    The only valid values are 'login', 'none', 'consent', and 'select_account'.
    *    @see https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
    * @param {Boolean} [options.ephemeralSession] SSO. It only affects iOS with versions 13 and above.
+   * @param {String} [options.login_hint] (optional). Provides a hint to Microsoft Entra ID 
+   *    about the user account attempting to sign in
+   *    @see https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-sso#using-a-login-hint
    * @returns {Promise<BaseTokenItem | AccessTokenItem>}
    *
    * @memberof WebAuth

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -303,10 +303,14 @@ declare class WebAuth {
    *    @see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes
    * @param {String} [options.prompt] (optional) indicates the type of user interaction that is required.
    *    The only valid values at this time are 'login', 'none', and 'consent'.
+  * @param {String} [options.login_hint] (optional). Provides a hint to Microsoft Entra ID 
+   *    about the user account attempting to sign in
+   *    @see https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-sso#using-a-login-hint 
    */
   authorize(options: {
     prompt?: string;
     scope?: string;
+    login_hint?: string;
   }): Promise<BaseTokenItem & Partial<AccessTokenItem>>;
   /**
    *  Removes Azure session


### PR DESCRIPTION
Currently, I have a use case whenever I begin to authorize with Azure, I can be able to fill up the email text field in the Microsoft login page with the email my user typed in the text field in the previous login screen. 

This PR will solve that using the login_hint param which is described below. This only updates the JS Docs and Typescript type definition so the compiler won't get an error about missing the type of `login_hint`.

https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-sso#using-a-login-hint

https://github.com/user-attachments/assets/b67dd5b7-ea86-4420-bb7a-0078008cb46f

