### PR TITLE
Allow setting androidx.browser:browser version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,8 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.browser:browser:+'
+    def androidXVersion = safeExtGet('androidXVersion', '+')
+    def androidXBrowser = safeExtGet('androidXBrowser', androidXVersion)
+    implementation "androidx.browser:browser:$androidXBrowser"
 }
 


### PR DESCRIPTION
Recenty a new version `1.9.0-alpha02` was released for `androidx.browser:browser` and that version requires compileSdk 36 (which seems to still be in beta at the moment). That breaks Android builds for React Native apps using compileSdk 35.

![Screenshot 2025-04-16 at 12 07 16](https://github.com/user-attachments/assets/270b1274-807d-40ab-99fc-14aa0d85642b)

Other dependencies allow setting a version explicitly in `android/build.gradle` with `androidXVersion` or `androidXBrowser`:
- https://github.com/hyochan/react-native-iap/blob/12.16.2/android/build.gradle#L156
- https://github.com/proyecto26/react-native-inappbrowser/blob/v3.7.0/android/build.gradle#L66

This way the app can fix the version in `android/build.gradle` like this:
```
buildscript {
    ext {
        // ...
        androidXVersion = "1.8.0"
    }
    // ...
}
```

This change implements a similar solution.