### PR TITLE
Reject promise with error data in refreshTokens

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -158,7 +158,8 @@ export default class Auth {
                     // on missing consent Azure also answers with HTTP 400 code
                     // Error: AADSTS65001, response.json.error_codes[0] == 65001
                     log.error('Could not refresh token: ', response)
-                    return Promise.reject(null)
+                    const error = new AuthError(response)
+                    return Promise.reject(error)
                 }
             })
     }


### PR DESCRIPTION
**What does this PR do?**
Reject promise with error data on `refreshTokens` method when the response is not ok.

**Context:**
PR created based on this reported issue: https://github.com/vmurin/react-native-azure-auth/issues/241