### PR TITLE
cast content-length header to string

### DIFF
--- a/src/auth/__tests__/__snapshots__/auth.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/auth.spec.js.snap
@@ -21,7 +21,7 @@ exports[`auth code exchange should send correct payload 1`] = `
     "body": "&code=a%20code&code_verifier=some%20Azure%20verifier%20code&scope=openid&client_id=A_CLIENT_ID_OF_YOUR_ACCOUNT&redirect_uri=my_bundle_id%3A%2F%2Fmy_bundle_id%2FSomeMobile%2Fcallback&grant_type=authorization_code",
     "headers": {
       "Accept": "application/json, image/*;q=0.1",
-      "Content-Length": 211,
+      "Content-Length": "211",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "POST",
@@ -74,7 +74,7 @@ exports[`auth refresh token should send correct payload 1`] = `
     "body": "&refresh_token=a%20refresh%20token%20of%20a%20user&scope=offline_access%20openid%20profile&client_id=A_CLIENT_ID_OF_YOUR_ACCOUNT&grant_type=refresh_token&redirect_uri=my_bundle_id%3A%2F%2Fmy_bundle_id%2FSomeMobile%2Fcallback",
     "headers": {
       "Accept": "application/json, image/*;q=0.1",
-      "Content-Length": 224,
+      "Content-Length": "224",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "POST",

--- a/src/networking/__tests__/__snapshots__/networking.spec.js.snap
+++ b/src/networking/__tests__/__snapshots__/networking.spec.js.snap
@@ -73,7 +73,7 @@ exports[`client requests PATCH json should build proper request with body 1`] = 
     "headers": {
       "Accept": "application/json, image/*;q=0.1",
       "Authorization": "Bearer a.bearer.token",
-      "Content-Length": 23,
+      "Content-Length": "23",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "PATCH",
@@ -136,7 +136,7 @@ exports[`client requests POST json should build proper request with body 1`] = `
     "headers": {
       "Accept": "application/json, image/*;q=0.1",
       "Authorization": "Bearer a.bearer.token",
-      "Content-Length": 23,
+      "Content-Length": "23",
       "Content-Type": "application/x-www-form-urlencoded",
     },
     "method": "POST",

--- a/src/networking/index.js
+++ b/src/networking/index.js
@@ -82,7 +82,7 @@ export default class Client {
         if (body) {
             // POST
             options.body = serializeParams(body)
-            options.headers['Content-Length'] = options.body.length
+            options.headers['Content-Length'] = String(options.body.length)
         }
 
         let response = await fetch(url, options)


### PR DESCRIPTION
The library does not work with new RN version anymore, and this PR fixes the issue. 

RN 0.85 has removed the legacy bridge, which was lenient about types. The new architecture uses direct javascript interface with direct C++ bindings that enforce strict types. Network request header values now except strings, and number won't get coerced anymore.